### PR TITLE
受講生情報の論理削除機能を追加

### DIFF
--- a/src/main/java/student/management/StudentManagement/data/Student.java
+++ b/src/main/java/student/management/StudentManagement/data/Student.java
@@ -16,5 +16,5 @@ public class Student {
   private int age;
   private String gender;
   private String remark;
-  private boolean deleted;
+  private boolean isDeleted;
 }

--- a/src/main/java/student/management/StudentManagement/data/Student.java
+++ b/src/main/java/student/management/StudentManagement/data/Student.java
@@ -16,5 +16,5 @@ public class Student {
   private int age;
   private String gender;
   private String remark;
-  private boolean isDeleted;
+  private boolean deleted;
 }

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -41,7 +41,7 @@ public interface StudentRepository {
 
   //  学生情報を更新
   @Update("UPDATE students SET name = #{name}, kana_name = #{kanaName}, nickname =  #{nickname}, "
-      + "email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{deleted} WHERE id = #{id}")
+      + "email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted} WHERE id = #{id}")
   void updateStudent(Student student);
 
   //  コース情報を更新

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -13,7 +13,7 @@ import student.management.StudentManagement.data.StudentCourses;
 public interface StudentRepository {
 
   //  受講生情報全件取得
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE is_deleted = false")
   List<Student> getAllStudents();
 
   //  コース全件取得
@@ -41,7 +41,7 @@ public interface StudentRepository {
 
   //  学生情報を更新
   @Update("UPDATE students SET name = #{name}, kana_name = #{kanaName}, nickname =  #{nickname}, "
-      + "email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark} WHERE id = #{id}")
+      + "email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{deleted} WHERE id = #{id}")
   void updateStudent(Student student);
 
   //  コース情報を更新

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,4 @@ spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 mybatis.configuration.map-underscore-to-camel-case=true
-mybatis.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl
+#mybatis.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -70,6 +70,10 @@
     </div>
   </div>
   <div>
+    <input type="checkbox" id="deleted" name="deleted" th:field="*{student.deleted}">
+    <label for="deleted">削除する</label>
+  </div>
+  <div>
     <button type="submit">更新</button>
   </div>
 </form>


### PR DESCRIPTION
## 動画No.
30_受講生情報更新処理の実装

## 課題内容
受講生情報の「削除」処理を実装
- 受講生個別ページに「削除する」のチェックボックスを追加
- チェックして更新した場合、studentsテーブルのis_deletedをtrueにする
- 受講生一覧ページには、is_deletedがfalseの学生のみを表示

## 実行結果
- 受講生個別ページ
![スクリーンショット 2025-03-06 11 26 18](https://github.com/user-attachments/assets/66be82d1-daaa-4cb4-bd1e-58d0ad58e32d)

- 受講生一覧ページ（削除した山田花子さんのデータが表示されない）
![スクリーンショット 2025-03-06 11 26 38](https://github.com/user-attachments/assets/a853021e-1fb1-4361-981e-ff5723937625)

- studentsテーブル（is_deleted = trueの学生一覧）
![スクリーンショット 2025-03-06 11 27 00](https://github.com/user-attachments/assets/144032f6-0d5f-40db-84e0-28a26189fad7)
