### PR TITLE
サービスの受講生検索、登録、更新処理のテストを追加

### DIFF
--- a/src/test/java/student/management/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/student/management/StudentManagement/service/StudentServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import student.management.StudentManagement.controller.converter.StudentConverter;
 import student.management.StudentManagement.data.Student;
 import student.management.StudentManagement.data.StudentCourses;
+import student.management.StudentManagement.domain.StudentDetail;
 import student.management.StudentManagement.repository.StudentRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,4 +56,71 @@ class StudentServiceTest {
     verify(repository, times(1)).getAllCourses();
     verify(converter, times(1)).convertStudentDetails(studentList, studentCoursesList);
   }
+
+  @Test
+  void 受講生詳細の検索_リポジトリの処理が適切に呼び出せること() {
+    String id = "1";
+
+//    モックデータを準備
+    Student student = new Student();
+    List<StudentCourses> studentCourses = new ArrayList<>();
+
+//    想定される挙動
+    when(repository.searchStudent(id)).thenReturn(Optional.of(student));
+    when(repository.searchStudentCourses(student.getId())).thenReturn(studentCourses);
+
+//    実際に呼び出し
+    sut.searchStudent(id);
+
+//    確認
+    verify(repository, times(1)).searchStudent(id);
+    verify(repository, times(1)).searchStudentCourses(student.getId());
+  }
+
+  @Test
+  void 受講生登録_リポジトリの処理が適切に呼び出せること() {
+    //    モックデータを準備
+    Student student = new Student();
+    List<StudentCourses> studentCourses = new ArrayList<>();
+    StudentDetail studentDetail = new StudentDetail(student, studentCourses);
+
+    //    コース情報をセット
+    StudentCourses course1 = new StudentCourses();
+    StudentCourses course2 = new StudentCourses();
+    studentCourses.add(course1);
+    studentCourses.add(course2);
+
+//    実際に呼び出し
+    sut.registerStudent(studentDetail);
+
+//    確認
+    verify(repository, times(1)).registerStudent(studentDetail.getStudent());
+    verify(repository, times(1)).registerStudentCourse(course1);
+    verify(repository, times(1)).registerStudentCourse(course2);
+
+  }
+
+  @Test
+  void 受講生詳細の更新_リポジトリの処理が適切に呼び出せること() {
+//    モックデータを準備
+    Student student = new Student();
+    List<StudentCourses> studentCourses = new ArrayList<>();
+    StudentDetail studentDetail = new StudentDetail(student, studentCourses);
+
+    //    コース情報をセット
+    StudentCourses course1 = new StudentCourses();
+    StudentCourses course2 = new StudentCourses();
+    studentCourses.add(course1);
+    studentCourses.add(course2);
+
+//    実際に呼び出し
+    sut.updateStudent(studentDetail);
+
+//    確認
+    verify(repository, times(1)).updateStudent(studentDetail.getStudent());
+    verify(repository, times(1)).updateStudentCourses(course1);
+    verify(repository, times(1)).updateStudentCourses(course2);
+
+  }
+
 }


### PR DESCRIPTION
## 講義No.
40_JUnitとAssertionとMockito_Serviceのテスト

## 想定する挙動
searchStudent, registerStudent, updateStudentのテストがパスすること

## 実行結果
すべてテストはパスしました。

- searchStudent
![searchStudent](https://github.com/user-attachments/assets/413564bd-3e11-44c5-80db-9f70a4454afb)

- registerStudent
![registerStudent](https://github.com/user-attachments/assets/46ffea5d-fdf4-47d6-b4b8-ed20d4099653)

- updateStudent
![updateStudent](https://github.com/user-attachments/assets/03727330-31fd-4a73-b50d-b187ce98949a)
